### PR TITLE
(#16) Resetting Alarms everytime Chrome starts

### DIFF
--- a/background.js
+++ b/background.js
@@ -18,6 +18,10 @@ chrome.storage.sync.get(['checkedNotifications'], function(storedData) {
 			priority: 0
 		});
 	});
+
+	chrome.runtime.onStartup.addListener(function () {
+		setAlarms(storedCheckedNotifications);
+	});
 });
 
 function getObjectElement(haystack, key, value) {
@@ -27,4 +31,17 @@ function getObjectElement(haystack, key, value) {
 		}
 	}
 	return false;
+}
+
+function setAlarms(checkedNotifications){
+	chrome.alarms.clearAll();
+	checkedNotifications.forEach(function(notification){
+		chrome.alarms.create(
+			notification.id,
+			{
+				when: Date.now() + notification.cycleTime * 60000,
+				periodInMinutes: notification.cycleTime
+			}
+		);
+	});
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "Mind me please",
-	"version": "1.0",
+	"version": "1.0.2",
 	"description": "Health reminders while working on the desk",
 	"icons": {
 		"128": "assets/png/icon128.png",

--- a/popup/index.js
+++ b/popup/index.js
@@ -49,6 +49,7 @@ function getCheckedNotifications(storedCheckedNotifications) {
 					'id': checkedNotification.id,
 					'title': checkedNotification.title,
 					'quote': checkedNotification.quote,
+					'cycleTime': checkedNotification.cycleTime
 				});
 			}
 		}


### PR DESCRIPTION
Resolves #16 
#### Changes include:
- Store notification cycletime also with other notifications properties
- Resetting alarms every time chrome starts